### PR TITLE
feat: add RPC provider abstraction layer

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,31 +1,72 @@
 # Database
 DATABASE_URL=postgresql://mempool:mempool_password@localhost:5432/mempool
 
-# Server ports
+# Server Configuration
 PORT=3001
 WS_PORT=3002
 
-# Chain configurations (add as many as needed)
-# Format: CHAIN_{N}_{PROPERTY}
-# Required properties: NAME, ID, WS_URL
-# Optional: RPC_URL (for HTTP fallback)
+# =============================================================================
+# RPC PROVIDER CONFIGURATION (Recommended)
+# =============================================================================
+# Option 1: Single Provider (Simplest)
+# Automatically generates endpoints for all supported chains
+PROVIDER=alchemy
+ALCHEMY_API_KEY=your_alchemy_api_key_here
+
+# Option 2: Multiple Providers with Failover
+# Providers are tried in order (alchemy first, then quicknode)
+# PROVIDERS=alchemy,quicknode
+# ALCHEMY_API_KEY=your_alchemy_key
+# QUICKNODE_API_KEY=your_quicknode_key
+
+# Available Providers:
+# - alchemy: Ethereum, Optimism, Polygon, Arbitrum, Base + testnets
+# - quicknode: Most EVM chains including BSC, Avalanche
+# - infura: Ethereum, Optimism, Polygon, Arbitrum, Avalanche
+# - ankr: Wide range of EVM chains including Fantom
+
+# =============================================================================
+# CHAIN CONFIGURATION
+# =============================================================================
+# When using providers above, you only need to specify NAME and ID
+# WebSocket URLs are generated automatically
 
 # Ethereum Mainnet
 CHAIN_1_NAME=ethereum
 CHAIN_1_ID=1
-CHAIN_1_WS_URL=wss://your-provider.com/ws/v2/YOUR_API_KEY
 
 # Base
 CHAIN_2_NAME=base
 CHAIN_2_ID=8453
-CHAIN_2_WS_URL=wss://your-provider.com/base-mainnet/ws/v2/YOUR_API_KEY
 
 # Arbitrum (example)
 # CHAIN_3_NAME=arbitrum
 # CHAIN_3_ID=42161
-# CHAIN_3_WS_URL=wss://your-provider.com/arbitrum-mainnet/ws/v2/YOUR_API_KEY
 
 # Polygon (example)
 # CHAIN_4_NAME=polygon
 # CHAIN_4_ID=137
-# CHAIN_4_WS_URL=wss://your-provider.com/polygon-mainnet/ws/v2/YOUR_API_KEY
+
+# =============================================================================
+# MANUAL CONFIGURATION (Backward compatible)
+# =============================================================================
+# You can still manually specify WebSocket URLs for any chain
+# This overrides provider-based configuration for that specific chain
+
+# Example: Custom RPC endpoint for Chain 1
+# CHAIN_1_WS_URL=wss://your-custom-endpoint.com/ws
+# CHAIN_1_RPC_URL=https://your-custom-endpoint.com
+
+# =============================================================================
+# MIXED CONFIGURATION EXAMPLE
+# =============================================================================
+# Use provider for most chains, but custom endpoint for one:
+# PROVIDER=alchemy
+# ALCHEMY_API_KEY=your_key
+# CHAIN_1_NAME=ethereum
+# CHAIN_1_ID=1                              # Uses Alchemy
+# CHAIN_2_NAME=base
+# CHAIN_2_ID=8453                           # Uses Alchemy
+# CHAIN_3_NAME=custom-chain
+# CHAIN_3_ID=999
+# CHAIN_3_WS_URL=wss://custom.com/ws        # Manual override

--- a/backend/src/config/chains.ts
+++ b/backend/src/config/chains.ts
@@ -1,31 +1,66 @@
 import type { ChainConfig } from '../mempool/types.js';
+import type { ProviderManager } from '../providers/manager.js';
 
 /**
  * Load chain configurations from environment variables.
  * Format: CHAIN_{N}_{PROPERTY} where N is 1, 2, 3, etc.
- * Required: NAME, ID, WS_URL
- * Optional: RPC_URL
+ * Required: NAME, ID
+ * Optional: WS_URL, RPC_URL (if not using provider manager)
+ *
+ * New: If providerManager is provided, URLs are auto-generated from providers
+ * Backward compatible: Manual WS_URL still works and takes precedence
  */
-export function loadChainsFromEnv(): ChainConfig[] {
+export function loadChainsFromEnv(providerManager?: ProviderManager): ChainConfig[] {
   const chains: ChainConfig[] = [];
   let index = 1;
 
   while (true) {
     const name = process.env[`CHAIN_${index}_NAME`];
     const id = process.env[`CHAIN_${index}_ID`];
-    const wsUrl = process.env[`CHAIN_${index}_WS_URL`];
-    const rpcUrl = process.env[`CHAIN_${index}_RPC_URL`];
 
-    if (!name || !id || !wsUrl) {
+    if (!name || !id) {
       break;
     }
 
-    chains.push({
-      id: parseInt(id, 10),
-      name,
-      wsUrl,
-      rpcUrl,
-    });
+    const chainId = parseInt(id, 10);
+
+    // Check for manual URL override first (backward compatibility)
+    const wsUrl = process.env[`CHAIN_${index}_WS_URL`];
+    const rpcUrl = process.env[`CHAIN_${index}_RPC_URL`];
+
+    if (wsUrl) {
+      // Manual configuration - use as-is
+      chains.push({
+        id: chainId,
+        name,
+        wsUrl,
+        rpcUrl,
+      });
+    } else if (providerManager) {
+      // Use provider manager to get endpoint
+      const endpoint = providerManager.getPrimaryEndpoint(chainId);
+
+      if (!endpoint) {
+        console.warn(`No provider endpoint available for ${name} (${chainId}). Skipping chain.`);
+        index++;
+        continue;
+      }
+
+      chains.push({
+        id: chainId,
+        name,
+        wsUrl: endpoint.wsUrl,
+        rpcUrl: endpoint.httpUrl,
+      });
+
+      console.log(`Using ${endpoint.provider} provider for ${name} (${chainId})`);
+    } else {
+      // No manual URL and no provider manager
+      console.error(
+        `Chain ${index} (${name}): No WS_URL provided and no provider manager configured`
+      );
+      break;
+    }
 
     index++;
   }

--- a/backend/src/providers/manager.test.ts
+++ b/backend/src/providers/manager.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ProviderManager } from './manager';
+import type { ProviderConfig } from './types';
+
+describe('ProviderManager', () => {
+    describe('constructor and validation', () => {
+        it('should create manager with valid Alchemy config', () => {
+            const config: ProviderConfig[] = [
+                { provider: 'alchemy', apiKey: 'test-key' },
+            ];
+
+            expect(() => new ProviderManager(config)).not.toThrow();
+        });
+
+        it('should create manager with multiple providers', () => {
+            const configs: ProviderConfig[] = [
+                { provider: 'alchemy', apiKey: 'alchemy-key' },
+                { provider: 'quicknode', apiKey: 'quicknode-key' },
+            ];
+
+            expect(() => new ProviderManager(configs)).not.toThrow();
+        });
+
+        it('should create manager with custom provider', () => {
+            const config: ProviderConfig[] = [
+                { provider: 'custom', customUrl: 'wss://custom.com/ws' },
+            ];
+
+            expect(() => new ProviderManager(config)).not.toThrow();
+        });
+
+        it('should throw error for unknown provider', () => {
+            const config: ProviderConfig[] = [
+                { provider: 'unknown' as any, apiKey: 'key' },
+            ];
+
+            expect(() => new ProviderManager(config)).toThrow(/Unknown provider/);
+        });
+
+        it('should throw error if custom provider missing customUrl', () => {
+            const config: ProviderConfig[] = [{ provider: 'custom' }];
+
+            expect(() => new ProviderManager(config)).toThrow(
+                /Custom provider requires customUrl/
+            );
+        });
+
+        it('should throw error if provider missing apiKey', () => {
+            const config: ProviderConfig[] = [{ provider: 'alchemy' }];
+
+            expect(() => new ProviderManager(config)).toThrow(/requires apiKey/);
+        });
+    });
+
+    describe('getEndpoints', () => {
+        it('should return Alchemy endpoint for Ethereum', () => {
+            const manager = new ProviderManager([
+                { provider: 'alchemy', apiKey: 'test-key' },
+            ]);
+
+            const endpoints = manager.getEndpoints(1);
+
+            expect(endpoints).toHaveLength(1);
+            expect(endpoints[0].wsUrl).toBe(
+                'wss://eth-mainnet.g.alchemy.com/v2/test-key'
+            );
+            expect(endpoints[0].httpUrl).toBe(
+                'https://eth-mainnet.g.alchemy.com/v2/test-key'
+            );
+            expect(endpoints[0].provider).toBe('alchemy');
+        });
+
+        it('should return multiple endpoints with failover', () => {
+            const manager = new ProviderManager([
+                { provider: 'alchemy', apiKey: 'alchemy-key' },
+                { provider: 'quicknode', apiKey: 'quicknode-key' },
+            ]);
+
+            const endpoints = manager.getEndpoints(1);
+
+            expect(endpoints).toHaveLength(2);
+            expect(endpoints[0].provider).toBe('alchemy');
+            expect(endpoints[1].provider).toBe('quicknode');
+        });
+
+        it('should skip providers that do not support chain', () => {
+            const manager = new ProviderManager([
+                { provider: 'infura', apiKey: 'infura-key' }, // Infura doesn't support Base
+                { provider: 'alchemy', apiKey: 'alchemy-key' }, // Alchemy supports Base
+            ]);
+
+            const endpoints = manager.getEndpoints(8453); // Base
+
+            expect(endpoints).toHaveLength(1);
+            expect(endpoints[0].provider).toBe('alchemy');
+        });
+
+        it('should return custom provider endpoint', () => {
+            const manager = new ProviderManager([
+                { provider: 'custom', customUrl: 'wss://my-custom.com/ws' },
+            ]);
+
+            const endpoints = manager.getEndpoints(1);
+
+            expect(endpoints).toHaveLength(1);
+            expect(endpoints[0].wsUrl).toBe('wss://my-custom.com/ws');
+            expect(endpoints[0].provider).toBe('custom');
+        });
+
+        it('should return empty array if no providers support chain', () => {
+            const manager = new ProviderManager([
+                { provider: 'infura', apiKey: 'test-key' },
+            ]);
+
+            const endpoints = manager.getEndpoints(99999);
+
+            expect(endpoints).toHaveLength(0);
+        });
+    });
+
+    describe('getPrimaryEndpoint', () => {
+        it('should return first available endpoint', () => {
+            const manager = new ProviderManager([
+                { provider: 'alchemy', apiKey: 'test-key' },
+            ]);
+
+            const endpoint = manager.getPrimaryEndpoint(1);
+
+            expect(endpoint).not.toBeNull();
+            expect(endpoint?.provider).toBe('alchemy');
+        });
+
+        it('should return null if no providers support chain', () => {
+            const manager = new ProviderManager([
+                { provider: 'infura', apiKey: 'test-key' },
+            ]);
+
+            const endpoint = manager.getPrimaryEndpoint(99999);
+
+            expect(endpoint).toBeNull();
+        });
+    });
+
+    describe('getEndpointForProvider', () => {
+        it('should return specific provider endpoint', () => {
+            const manager = new ProviderManager([
+                { provider: 'alchemy', apiKey: 'alchemy-key' },
+                { provider: 'quicknode', apiKey: 'quicknode-key' },
+            ]);
+
+            const endpoint = manager.getEndpointForProvider(1, 'quicknode');
+
+            expect(endpoint).not.toBeNull();
+            expect(endpoint?.provider).toBe('quicknode');
+        });
+
+        it('should return null if provider not configured', () => {
+            const manager = new ProviderManager([
+                { provider: 'alchemy', apiKey: 'test-key' },
+            ]);
+
+            const endpoint = manager.getEndpointForProvider(1, 'infura');
+
+            expect(endpoint).toBeNull();
+        });
+
+        it('should return null if provider does not support chain', () => {
+            const manager = new ProviderManager([
+                { provider: 'infura', apiKey: 'test-key' },
+            ]);
+
+            const endpoint = manager.getEndpointForProvider(8453, 'infura');
+
+            expect(endpoint).toBeNull();
+        });
+    });
+
+    describe('Helper methods', () => {
+        it('should check if chain is supported', () => {
+            const manager = new ProviderManager([
+                { provider: 'alchemy', apiKey: 'test-key' },
+            ]);
+
+            expect(manager.isChainSupported(1)).toBe(true);
+            expect(manager.isChainSupported(99999)).toBe(false);
+        });
+
+        it('should return configured providers', () => {
+            const manager = new ProviderManager([
+                { provider: 'alchemy', apiKey: 'key1' },
+                { provider: 'quicknode', apiKey: 'key2' },
+            ]);
+
+            const providers = manager.getConfiguredProviders();
+
+            expect(providers).toEqual(['alchemy', 'quicknode']);
+        });
+    });
+
+    describe('loadProvidersFromEnv', () => {
+        beforeEach(() => {
+            // Clear environment
+            vi.unstubAllEnvs();
+        });
+
+        it('should load single provider from env', async () => {
+            vi.stubEnv('PROVIDER', 'alchemy');
+            vi.stubEnv('ALCHEMY_API_KEY', 'test-key');
+
+            const { loadProvidersFromEnv } = await import('./manager');
+            const configs = loadProvidersFromEnv();
+
+            expect(configs).toHaveLength(1);
+            expect(configs[0].provider).toBe('alchemy');
+            expect(configs[0].apiKey).toBe('test-key');
+        });
+
+        it('should load multiple providers from PROVIDERS env', async () => {
+            vi.stubEnv('PROVIDERS', 'alchemy,quicknode');
+            vi.stubEnv('ALCHEMY_API_KEY', 'alchemy-key');
+            vi.stubEnv('QUICKNODE_API_KEY', 'quicknode-key');
+
+            const { loadProvidersFromEnv } = await import('./manager');
+            const configs = loadProvidersFromEnv();
+
+            expect(configs).toHaveLength(2);
+            expect(configs[0].provider).toBe('alchemy');
+            expect(configs[1].provider).toBe('quicknode');
+        });
+
+        it('should return empty array if no providers configured', async () => {
+            const { loadProvidersFromEnv } = await import('./manager');
+            const configs = loadProvidersFromEnv();
+
+            expect(configs).toHaveLength(0);
+        });
+
+        it('should skip provider if API key missing', async () => {
+            vi.stubEnv('PROVIDERS', 'alchemy,quicknode');
+            vi.stubEnv('ALCHEMY_API_KEY', 'alchemy-key');
+            // QUICKNODE_API_KEY missing
+
+            const { loadProvidersFromEnv } = await import('./manager');
+            const configs = loadProvidersFromEnv();
+
+            expect(configs).toHaveLength(1);
+            expect(configs[0].provider).toBe('alchemy');
+        });
+    });
+});

--- a/backend/src/providers/manager.ts
+++ b/backend/src/providers/manager.ts
@@ -1,0 +1,178 @@
+import type { ProviderConfig, ProviderEndpoints, RpcProvider } from './types';
+import { getProvider } from './registry';
+
+/**
+ * Provider Manager
+ * Handles provider selection, endpoint building, and failover
+ */
+export class ProviderManager {
+  private providerConfigs: ProviderConfig[];
+
+  constructor(configs: ProviderConfig[]) {
+    this.providerConfigs = configs;
+    this.validateConfigs();
+  }
+
+  /**
+   * Validate provider configurations
+   */
+  private validateConfigs(): void {
+    for (const config of this.providerConfigs) {
+      if (config.provider === 'custom') {
+        if (!config.customUrl) {
+          throw new Error('Custom provider requires customUrl');
+        }
+        continue;
+      }
+
+      const provider = getProvider(config.provider);
+      if (!provider) {
+        throw new Error(`Unknown provider: ${config.provider}`);
+      }
+
+      if (!config.apiKey && !config.customUrl) {
+        throw new Error(`Provider ${config.provider} requires apiKey or customUrl`);
+      }
+    }
+  }
+
+  /**
+   * Get all available endpoints for a chain (with failover)
+   */
+  getEndpoints(chainId: number): ProviderEndpoints[] {
+    const endpoints: ProviderEndpoints[] = [];
+
+    for (const config of this.providerConfigs) {
+      // Handle custom provider
+      if (config.provider === 'custom' && config.customUrl) {
+        endpoints.push({
+          wsUrl: config.customUrl,
+          provider: 'custom',
+        });
+        continue;
+      }
+
+      const provider = getProvider(config.provider);
+      if (!provider) continue;
+
+      // Check if provider supports this chain
+      if (!provider.supportsChain(chainId)) {
+        console.warn(`Provider ${provider.name} does not support chain ${chainId}, skipping`);
+        continue;
+      }
+
+      // Build endpoints
+      try {
+        if (config.apiKey) {
+          const wsUrl = provider.buildWebSocketUrl(chainId, config.apiKey);
+          const httpUrl = provider.supportsHttp
+            ? provider.buildHttpUrl(chainId, config.apiKey)
+            : undefined;
+
+          endpoints.push({
+            wsUrl,
+            httpUrl,
+            provider: config.provider,
+          });
+        }
+      } catch (error) {
+        console.error(
+          `Failed to build endpoint for ${config.provider} on chain ${chainId}:`,
+          error
+        );
+      }
+    }
+
+    return endpoints;
+  }
+
+  /**
+   * Get primary endpoint for a chain (first available)
+   */
+  getPrimaryEndpoint(chainId: number): ProviderEndpoints | null {
+    const endpoints = this.getEndpoints(chainId);
+    return endpoints[0] || null;
+  }
+
+  /**
+   * Get endpoint for a specific provider
+   */
+  getEndpointForProvider(chainId: number, providerName: string): ProviderEndpoints | null {
+    const config = this.providerConfigs.find((c) => c.provider === providerName);
+    if (!config) return null;
+
+    const provider = getProvider(providerName);
+    if (!provider || !provider.supportsChain(chainId)) return null;
+
+    if (!config.apiKey) return null;
+
+    try {
+      return {
+        wsUrl: provider.buildWebSocketUrl(chainId, config.apiKey),
+        httpUrl: provider.supportsHttp ? provider.buildHttpUrl(chainId, config.apiKey) : undefined,
+        provider: config.provider,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Check if any provider supports a chain
+   */
+  isChainSupported(chainId: number): boolean {
+    return this.getEndpoints(chainId).length > 0;
+  }
+
+  /**
+   * Get list of configured providers
+   */
+  getConfiguredProviders(): string[] {
+    return this.providerConfigs.map((c) => c.provider);
+  }
+}
+
+/**
+ * Load provider configurations from environment variables
+ */
+export function loadProvidersFromEnv(): ProviderConfig[] {
+  const configs: ProviderConfig[] = [];
+
+  // Check for PROVIDERS env var (comma-separated list)
+  const providersEnv = process.env.PROVIDERS;
+  if (providersEnv) {
+    const providerNames = providersEnv.split(',').map((p) => p.trim());
+
+    for (const providerName of providerNames) {
+      const apiKeyEnv = `${providerName.toUpperCase()}_API_KEY`;
+      const apiKey = process.env[apiKeyEnv];
+
+      if (apiKey) {
+        configs.push({
+          provider: providerName as any,
+          apiKey,
+        });
+      } else {
+        console.warn(`No API key found for provider ${providerName} (${apiKeyEnv})`);
+      }
+    }
+  }
+
+  // Check for single PROVIDER env var
+  const singleProvider = process.env.PROVIDER;
+  if (singleProvider && configs.length === 0) {
+    const apiKeyEnv = `${singleProvider.toUpperCase()}_API_KEY`;
+    const apiKey = process.env[apiKeyEnv];
+
+    if (apiKey) {
+      configs.push({
+        provider: singleProvider as any,
+        apiKey,
+      });
+    }
+  }
+
+  // If no providers configured, return empty array
+  // (will fall back to manual URLs in chain config)
+  return configs;
+}

--- a/backend/src/providers/providers.test.ts
+++ b/backend/src/providers/providers.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { AlchemyProvider } from './providers/alchemy';
+import { QuickNodeProvider } from './providers/quicknode';
+import { InfuraProvider } from './providers/infura';
+import { AnkrProvider } from './providers/ankr';
+
+describe('Provider Registry', () => {
+    describe('AlchemyProvider', () => {
+        it('should build correct WebSocket URL for Ethereum', () => {
+            const url = AlchemyProvider.buildWebSocketUrl(1, 'test-api-key');
+            expect(url).toBe('wss://eth-mainnet.g.alchemy.com/v2/test-api-key');
+        });
+
+        it('should build correct WebSocket URL for Base', () => {
+            const url = AlchemyProvider.buildWebSocketUrl(8453, 'test-api-key');
+            expect(url).toBe('wss://base-mainnet.g.alchemy.com/v2/test-api-key');
+        });
+
+        it('should build correct HTTP URL for Arbitrum', () => {
+            const url = AlchemyProvider.buildHttpUrl(42161, 'test-api-key');
+            expect(url).toBe('https://arb-mainnet.g.alchemy.com/v2/test-api-key');
+        });
+
+        it('should support Ethereum mainnet', () => {
+            expect(AlchemyProvider.supportsChain(1)).toBe(true);
+        });
+
+        it('should support Base', () => {
+            expect(AlchemyProvider.supportsChain(8453)).toBe(true);
+        });
+
+        it('should not support unknown chains', () => {
+            expect(AlchemyProvider.supportsChain(99999)).toBe(false);
+        });
+
+        it('should throw error for unsupported chain', () => {
+            expect(() => AlchemyProvider.buildWebSocketUrl(99999, 'key')).toThrow(
+                /does not support/
+            );
+        });
+
+        it('should have WebSocket and HTTP support', () => {
+            expect(AlchemyProvider.supportsWebSocket).toBe(true);
+            expect(AlchemyProvider.supportsHttp).toBe(true);
+        });
+    });
+
+    describe('QuickNodeProvider', () => {
+        it('should build correct WebSocket URL for Ethereum', () => {
+            const url = QuickNodeProvider.buildWebSocketUrl(1, 'test-hash');
+            expect(url).toBe('wss://ethereum-mainnet.quiknode.pro/test-hash/');
+        });
+
+        it('should build correct HTTP URL for BSC', () => {
+            const url = QuickNodeProvider.buildHttpUrl(56, 'test-hash');
+            expect(url).toBe('https://bsc.quiknode.pro/test-hash/');
+        });
+
+        it('should support Avalanche', () => {
+            expect(QuickNodeProvider.supportsChain(43114)).toBe(true);
+        });
+
+        it('should throw error for unsupported chain', () => {
+            expect(() => QuickNodeProvider.buildWebSocketUrl(99999, 'key')).toThrow(
+                /does not support/
+            );
+        });
+    });
+
+    describe('InfuraProvider', () => {
+        it('should build correct WebSocket URL for Ethereum', () => {
+            const url = InfuraProvider.buildWebSocketUrl(1, 'test-project-id');
+            expect(url).toBe('wss://mainnet.infura.io/ws/v3/test-project-id');
+        });
+
+        it('should build correct HTTP URL for Polygon', () => {
+            const url = InfuraProvider.buildHttpUrl(137, 'test-project-id');
+            expect(url).toBe('https://polygon-mainnet.infura.io/v3/test-project-id');
+        });
+
+        it('should support Optimism', () => {
+            expect(InfuraProvider.supportsChain(10)).toBe(true);
+        });
+
+        it('should not support Base (Infura limitation)', () => {
+            expect(InfuraProvider.supportsChain(8453)).toBe(false);
+        });
+    });
+
+    describe('AnkrProvider', () => {
+        it('should build correct WebSocket URL for Ethereum', () => {
+            const url = AnkrProvider.buildWebSocketUrl(1, 'test-key');
+            expect(url).toBe('wss://rpc.ankr.com/eth/ws/test-key');
+        });
+
+        it('should build correct HTTP URL for Fantom', () => {
+            const url = AnkrProvider.buildHttpUrl(250, 'test-key');
+            expect(url).toBe('https://rpc.ankr.com/fantom/test-key');
+        });
+
+        it('should support Base', () => {
+            expect(AnkrProvider.supportsChain(8453)).toBe(true);
+        });
+
+        it('should support Fantom', () => {
+            expect(AnkrProvider.supportsChain(250)).toBe(true);
+        });
+    });
+
+    describe('Provider Metadata', () => {
+        it('should have correct provider names', () => {
+            expect(AlchemyProvider.name).toBe('Alchemy');
+            expect(QuickNodeProvider.name).toBe('QuickNode');
+            expect(InfuraProvider.name).toBe('Infura');
+            expect(AnkrProvider.name).toBe('Ankr');
+        });
+
+        it('should all support WebSocket', () => {
+            expect(AlchemyProvider.supportsWebSocket).toBe(true);
+            expect(QuickNodeProvider.supportsWebSocket).toBe(true);
+            expect(InfuraProvider.supportsWebSocket).toBe(true);
+            expect(AnkrProvider.supportsWebSocket).toBe(true);
+        });
+
+        it('should all support HTTP', () => {
+            expect(AlchemyProvider.supportsHttp).toBe(true);
+            expect(QuickNodeProvider.supportsHttp).toBe(true);
+            expect(InfuraProvider.supportsHttp).toBe(true);
+            expect(AnkrProvider.supportsHttp).toBe(true);
+        });
+    });
+});

--- a/backend/src/providers/providers/alchemy.ts
+++ b/backend/src/providers/providers/alchemy.ts
@@ -1,0 +1,50 @@
+import type { RpcProvider } from '../types';
+
+/**
+ * Alchemy network mappings for different chains
+ */
+const ALCHEMY_NETWORKS: Record<number, string> = {
+  1: 'eth-mainnet', // Ethereum Mainnet
+  5: 'eth-goerli', // Goerli Testnet
+  11155111: 'eth-sepolia', // Sepolia Testnet
+  10: 'opt-mainnet', // Optimism
+  420: 'opt-goerli', // Optimism Goerli
+  137: 'polygon-mainnet', // Polygon
+  80001: 'polygon-mumbai', // Polygon Mumbai
+  42161: 'arb-mainnet', // Arbitrum One
+  421613: 'arb-goerli', // Arbitrum Goerli
+  8453: 'base-mainnet', // Base
+  84531: 'base-goerli', // Base Goerli
+  84532: 'base-sepolia', // Base Sepolia
+};
+
+export const AlchemyProvider: RpcProvider = {
+  name: 'Alchemy',
+  supportedChains: Object.keys(ALCHEMY_NETWORKS).map(Number),
+  supportsWebSocket: true,
+  supportsHttp: true,
+
+  buildWebSocketUrl(chainId: number, apiKey: string): string {
+    const network = ALCHEMY_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `Alchemy does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    return `wss://${network}.g.alchemy.com/v2/${apiKey}`;
+  },
+
+  buildHttpUrl(chainId: number, apiKey: string): string {
+    const network = ALCHEMY_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `Alchemy does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    return `https://${network}.g.alchemy.com/v2/${apiKey}`;
+  },
+
+  supportsChain(chainId: number): boolean {
+    return chainId in ALCHEMY_NETWORKS;
+  },
+};

--- a/backend/src/providers/providers/ankr.ts
+++ b/backend/src/providers/providers/ankr.ts
@@ -1,0 +1,52 @@
+import type { RpcProvider } from '../types';
+
+/**
+ * Ankr network mappings
+ */
+const ANKR_NETWORKS: Record<number, string> = {
+  1: 'eth',
+  5: 'eth_goerli',
+  10: 'optimism',
+  137: 'polygon',
+  80001: 'polygon_mumbai',
+  42161: 'arbitrum',
+  8453: 'base',
+  56: 'bsc',
+  97: 'bsc_testnet_chapel',
+  43114: 'avalanche',
+  43113: 'avalanche_fuji',
+  250: 'fantom',
+  4002: 'fantom_testnet',
+};
+
+export const AnkrProvider: RpcProvider = {
+  name: 'Ankr',
+  supportedChains: Object.keys(ANKR_NETWORKS).map(Number),
+  supportsWebSocket: true,
+  supportsHttp: true,
+
+  buildWebSocketUrl(chainId: number, apiKey: string): string {
+    const network = ANKR_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `Ankr does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    // Ankr format: wss://rpc.ankr.com/network/ws/apikey
+    return `wss://rpc.ankr.com/${network}/ws/${apiKey}`;
+  },
+
+  buildHttpUrl(chainId: number, apiKey: string): string {
+    const network = ANKR_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `Ankr does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    return `https://rpc.ankr.com/${network}/${apiKey}`;
+  },
+
+  supportsChain(chainId: number): boolean {
+    return chainId in ANKR_NETWORKS;
+  },
+};

--- a/backend/src/providers/providers/infura.ts
+++ b/backend/src/providers/providers/infura.ts
@@ -1,0 +1,49 @@
+import type { RpcProvider } from '../types';
+
+/**
+ * Infura network mappings
+ */
+const INFURA_NETWORKS: Record<number, string> = {
+  1: 'mainnet',
+  5: 'goerli',
+  11155111: 'sepolia',
+  10: 'optimism-mainnet',
+  420: 'optimism-goerli',
+  137: 'polygon-mainnet',
+  80001: 'polygon-mumbai',
+  42161: 'arbitrum-mainnet',
+  421613: 'arbitrum-goerli',
+  43114: 'avalanche-mainnet',
+  43113: 'avalanche-fuji',
+};
+
+export const InfuraProvider: RpcProvider = {
+  name: 'Infura',
+  supportedChains: Object.keys(INFURA_NETWORKS).map(Number),
+  supportsWebSocket: true,
+  supportsHttp: true,
+
+  buildWebSocketUrl(chainId: number, apiKey: string): string {
+    const network = INFURA_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `Infura does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    return `wss://${network}.infura.io/ws/v3/${apiKey}`;
+  },
+
+  buildHttpUrl(chainId: number, apiKey: string): string {
+    const network = INFURA_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `Infura does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    return `https://${network}.infura.io/v3/${apiKey}`;
+  },
+
+  supportsChain(chainId: number): boolean {
+    return chainId in INFURA_NETWORKS;
+  },
+};

--- a/backend/src/providers/providers/quicknode.ts
+++ b/backend/src/providers/providers/quicknode.ts
@@ -1,0 +1,53 @@
+import type { RpcProvider } from '../types';
+
+/**
+ * QuickNode network mappings
+ */
+const QUICKNODE_NETWORKS: Record<number, string> = {
+  1: 'ethereum-mainnet',
+  5: 'ethereum-goerli',
+  11155111: 'ethereum-sepolia',
+  10: 'optimism',
+  137: 'polygon-mainnet',
+  80001: 'polygon-testnet',
+  42161: 'arbitrum-mainnet',
+  421613: 'arbitrum-goerli',
+  8453: 'base-mainnet',
+  84531: 'base-goerli',
+  56: 'bsc',
+  97: 'bsc-testnet',
+  43114: 'avalanche-mainnet',
+  43113: 'avalanche-testnet',
+};
+
+export const QuickNodeProvider: RpcProvider = {
+  name: 'QuickNode',
+  supportedChains: Object.keys(QUICKNODE_NETWORKS).map(Number),
+  supportsWebSocket: true,
+  supportsHttp: true,
+
+  buildWebSocketUrl(chainId: number, apiKey: string): string {
+    const network = QUICKNODE_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `QuickNode does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    // QuickNode uses the format: wss://network.quiknode.pro/hash/
+    return `wss://${network}.quiknode.pro/${apiKey}/`;
+  },
+
+  buildHttpUrl(chainId: number, apiKey: string): string {
+    const network = QUICKNODE_NETWORKS[chainId];
+    if (!network) {
+      throw new Error(
+        `QuickNode does not support chain ID ${chainId}. Supported chains: ${this.supportedChains.join(', ')}`
+      );
+    }
+    return `https://${network}.quiknode.pro/${apiKey}/`;
+  },
+
+  supportsChain(chainId: number): boolean {
+    return chainId in QUICKNODE_NETWORKS;
+  },
+};

--- a/backend/src/providers/registry.ts
+++ b/backend/src/providers/registry.ts
@@ -1,0 +1,43 @@
+import type { RpcProvider } from './types';
+import { AlchemyProvider } from './providers/alchemy';
+import { QuickNodeProvider } from './providers/quicknode';
+import { InfuraProvider } from './providers/infura';
+import { AnkrProvider } from './providers/ankr';
+
+/**
+ * Registry of all available RPC providers
+ */
+export const PROVIDER_REGISTRY: Record<string, RpcProvider> = {
+  alchemy: AlchemyProvider,
+  quicknode: QuickNodeProvider,
+  infura: InfuraProvider,
+  ankr: AnkrProvider,
+};
+
+/**
+ * Get a provider by name
+ */
+export function getProvider(name: string): RpcProvider | undefined {
+  return PROVIDER_REGISTRY[name.toLowerCase()];
+}
+
+/**
+ * Get all available provider names
+ */
+export function getAvailableProviders(): string[] {
+  return Object.keys(PROVIDER_REGISTRY);
+}
+
+/**
+ * Check if a provider exists
+ */
+export function hasProvider(name: string): boolean {
+  return name.toLowerCase() in PROVIDER_REGISTRY;
+}
+
+/**
+ * Get providers that support a specific chain
+ */
+export function getProvidersForChain(chainId: number): RpcProvider[] {
+  return Object.values(PROVIDER_REGISTRY).filter((provider) => provider.supportsChain(chainId));
+}

--- a/backend/src/providers/types.ts
+++ b/backend/src/providers/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Provider configuration types for RPC provider abstraction
+ */
+
+export type ProviderName = 'alchemy' | 'quicknode' | 'infura' | 'ankr' | 'custom';
+
+export interface ProviderConfig {
+  provider: ProviderName;
+  apiKey?: string;
+  customUrl?: string; // For custom providers
+  timeout?: number;
+  retryConfig?: {
+    maxRetries: number;
+    retryDelay: number;
+  };
+}
+
+export interface RpcProvider {
+  name: string;
+  supportedChains: number[]; // Chain IDs
+  supportsWebSocket: boolean;
+  supportsHttp: boolean;
+
+  /**
+   * Build WebSocket URL for a specific chain
+   * @param chainId - The chain ID
+   * @param apiKey - Provider API key
+   * @returns WebSocket URL
+   */
+  buildWebSocketUrl(chainId: number, apiKey: string): string;
+
+  /**
+   * Build HTTP RPC URL for a specific chain
+   * @param chainId - The chain ID
+   * @param apiKey - Provider API key
+   * @returns HTTP URL
+   */
+  buildHttpUrl(chainId: number, apiKey: string): string;
+
+  /**
+   * Check if provider supports a specific chain
+   * @param chainId - The chain ID to check
+   * @returns True if chain is supported
+   */
+  supportsChain(chainId: number): boolean;
+}
+
+export interface ProviderEndpoints {
+  wsUrl: string;
+  httpUrl?: string;
+  provider: ProviderName;
+}
+
+/**
+ * Provider capabilities for documentation
+ */
+export interface ProviderCapabilities {
+  name: string;
+  websocketSupport: boolean;
+  httpSupport: boolean;
+  supportedChains: Array<{
+    id: number;
+    name: string;
+    network: string;
+  }>;
+}


### PR DESCRIPTION
- Add provider types and interfaces for provider abstraction
- Implement Alchemy, QuickNode, Infura, and Ankr providers
- Create ProviderManager for automatic endpoint generation
- Update chain configuration to support provider-based URLs
- Maintain backward compatibility with manual URLs
- Add 45 new tests for provider infrastructure (66 total passing)
- Update .env.example with provider configuration examples

Benefits:
- Simplified configuration: one API key instead of per-chain URLs
- Automatic failover with multiple providers
- Easy provider switching
- Validation of provider capabilities

Usage:
PROVIDER=alchemy
ALCHEMY_API_KEY=your_key
CHAIN_1_NAME=ethereum
CHAIN_1_ID=1